### PR TITLE
Typo in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "keywords": [
     "riotjs",
-    "redux-flux"
+    "redux-flux",
     "riot.js",
     "flux",
     "redux",


### PR DESCRIPTION
There's a typo in bower.json which prevents installation via bower. This PR fixes it.